### PR TITLE
Add jdk12 support, fix broken images/url

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ Go to the directory `sample` directory for more details.
 Building all samples in parallel (`docker-compose version 1.23.1, build b02f1306`)
 
 ```
-$ docker-compose -f docker-compose-samples.yaml build --parallel
+$ docker-compose -f docker-compose-samples.yml build --parallel
 Building sample-gradle-java-jre8          ...
 Building sample-gradle-java-jre10         ...
 Building samples-gradle-java-custom-jre10 ...
@@ -225,7 +225,7 @@ initialized via `InitContainer` and requires sources. There are 2 types as expla
 above and the sample is in JDK 11 cross-compiled
 
 ```
-$ docker-compose -f docker-compose-samples.yaml up --build samples-gradle-java-jdk8-x-jre-custom-11
+$ docker-compose -f docker-compose-samples.yml up --build samples-gradle-java-jdk8-x-jre-custom-11
 Building samples-gradle-java-jdk8-x-jre-custom-11
 Step 1/10 : ARG BUILDER_GIT_SHA=${GIT_SHA:-0101010}
 Step 2/10 : ARG BUILDER_GIT_BRANCH=${GIT_BRANCH:-develop}
@@ -311,7 +311,7 @@ samples-gradle-java-jdk8-x-jre-custom-11_1_76ab77ce7bd7 |  =========|_|=========
 ## Start all samples
 
 ```
-$ docker-compose -f docker-compose-samples.yaml up
+$ docker-compose -f docker-compose-samples.yml up
 ```
 
 # Contributing

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -114,7 +114,7 @@ services:
       context: linker
       args:
         - UNMAZEDBOOT_INTERNAL_BASE_IMAGE=alpine:3.8
-        - UNMAZEDBOOT_INTERNAL_DEPENDENCIES=wget https://download.java.net/java/early_access/alpine/25/binaries/openjdk-11-ea+25_linux-x64-musl_bin.tar.gz && tar zxf openjdk-11-ea+25_linux-x64-musl_bin.tar.gz && ln -s jdk-11 jdk && rm -f openjdk-11-ea+25_linux-x64-musl_bin.tar.gz
+        - UNMAZEDBOOT_INTERNAL_DEPENDENCIES=wget https://download.java.net/openjdk/jdk11/ri/openjdk-11+28_linux-x64_bin.tar.gz && tar -xvzf openjdk-11\+28_linux-x64_bin.tar.gz && ln -s jdk-11 jdk && rm -f openjdk-11\+28_linux-x64_bin.tar.gz
 
   # https://github.com/docker-library/openjdk/issues/217#issuecomment-436275472
   # Debian generates large libjvm and can be decreased
@@ -148,7 +148,7 @@ services:
     build:
       context: linker
       args:
-        - UNMAZEDBOOT_INTERNAL_BASE_IMAGE=sgrio/java-oracle:jdk_11_centos
+        - UNMAZEDBOOT_INTERNAL_BASE_IMAGE=sgrio/java:jdk_11_centos
         - UNMAZEDBOOT_INTERNAL_DEPENDENCIES=echo none
         - UNMAZEDBOOT_CUSTOM_JLINK_PATH=/usr/lib/jvm/java-11-oracle/bin/jlink
 
@@ -214,7 +214,7 @@ services:
       context: runner
       dockerfile: regular-jdk/Dockerfile
       args:
-        - UNMAZEDBOOT_INTERNAL_BASE_IMAGE=sgrio/java-oracle:jdk_11_centos
+        - UNMAZEDBOOT_INTERNAL_BASE_IMAGE=sgrio/java:jdk_11_centos
         - UNMAZEDBOOT_INTERNAL_DEPENDENCIES=echo none
 
   runner-oraclejdk-11-alpine:
@@ -223,5 +223,44 @@ services:
       context: runner
       dockerfile: regular-jdk/Dockerfile
       args:
-        - UNMAZEDBOOT_INTERNAL_BASE_IMAGE=sgrio/java-oracle:jdk_11_alpine
+        - UNMAZEDBOOT_INTERNAL_BASE_IMAGE=sgrio/java:jdk_11_alpine
         - UNMAZEDBOOT_INTERNAL_DEPENDENCIES=apk update && apk add bash ca-certificates libressl libressl-dev --no-cache && update-ca-certificates
+
+#JDK 12 runner images
+
+  runner-openjdk-12-alpine3.10:
+    image: intuit/unmazedboot-runner:openjdk14-ea-12-jdk-alpine3.10${UNMAZEDBOOT_RUNNER_VERSION}
+    build:
+      context: runner
+      dockerfile: regular-jdk/Dockerfile
+      args:
+        - UNMAZEDBOOT_INTERNAL_BASE_IMAGE=openjdk:14-ea-12-jdk-alpine3.10
+        - UNMAZEDBOOT_INTERNAL_DEPENDENCIES=apk update && apk add bash ca-certificates libressl libressl-dev --no-cache && update-ca-certificates
+
+  runner-oraclejdk-12-alpine:
+    image: intuit/unmazedboot-runner:oraclejdk-12-alpine${UNMAZEDBOOT_RUNNER_VERSION}
+    build:
+      context: runner
+      dockerfile: regular-jdk/Dockerfile
+      args:
+        - UNMAZEDBOOT_INTERNAL_BASE_IMAGE=sgrio/java:jdk_12_alpine
+        - UNMAZEDBOOT_INTERNAL_DEPENDENCIES=apk update && apk add bash ca-certificates libressl libressl-dev --no-cache && update-ca-certificates
+
+  runner-oraclejdk-jdk_12_centos:
+    image: intuit/unmazedboot-runner:oraclejdk-12-centos${UNMAZEDBOOT_RUNNER_VERSION}
+    build:
+      context: runner
+      dockerfile: regular-jdk/Dockerfile
+      args:
+        - UNMAZEDBOOT_INTERNAL_BASE_IMAGE=sgrio/java:jdk_12_centos
+        - UNMAZEDBOOT_INTERNAL_DEPENDENCIES=echo none
+
+  runner-openjdk-12-debian-slim:
+    image: intuit/unmazedboot-runner:openjdk-12-debian-slim${UNMAZEDBOOT_RUNNER_VERSION}
+    build:
+      context: runner
+      dockerfile: regular-jdk/Dockerfile
+      args:
+        - UNMAZEDBOOT_INTERNAL_BASE_IMAGE=adoptopenjdk/openjdk12:x86_64-debian-jdk-12.0.2_10-slim
+        - UNMAZEDBOOT_INTERNAL_DEPENDENCIES=apt-get update && apt-get install -y --no-install-recommends curl ca-certificates && apt-get clean && rm -rf /var/lib/apt/lists/*
+


### PR DESCRIPTION
### Requirements

Add support for JDK12


### Description of the Change


Add JDK12 runner image
Update repo. path for images, eg images under the repo path "sgrio/java-oracle:jdk_11_centos" have been moved to "sgrio/java:xyz"
Update READ ME


### Benefits

 It now supports JDK 12 runner images



